### PR TITLE
Allow users to ignore old php version extention warnings with the --since-version argument.

### DIFF
--- a/bin/phpca
+++ b/bin/phpca
@@ -8,7 +8,7 @@ use wapmorgan\PhpCodeAnalyzer\PhpCodeAnalyzer;
 
 $doc = <<<DOC
 Usage:
-    phpca [-v] [--no-report] [--no-progress] [FILES ...]
+    phpca [-v] [--no-report] [--no-progress] [--since-version=<version>] [FILES ...]
     phpca [-v] --extension=<ext> [FILES ...]
     phpca -h
 
@@ -18,6 +18,7 @@ Options:
   --extension=<ext> Look for usage a specific extension
   --no-report       Turn off summary report
   --no-progress     Turn off progress
+  --since-version=<version> Only include extensions not included since version
 
 DOC;
 
@@ -39,7 +40,7 @@ if (isset($args['--extension']))
 else
     $analyzer->loadData();
 
-if (isset($args['--since-version']))
+if (isset($args['--since-version']) && $args['--since-version'])
     $analyzer->setSinceVersion($args['--since-version']);
 
 if (!empty($args['FILES'])) {

--- a/bin/phpca
+++ b/bin/phpca
@@ -39,6 +39,9 @@ if (isset($args['--extension']))
 else
     $analyzer->loadData();
 
+if (isset($args['--since-version']))
+    $analyzer->setSinceVersion($args['--since-version']);
+
 if (!empty($args['FILES'])) {
     foreach ($args['FILES'] as $file) {
         if (is_dir($file)) {

--- a/src/PhpCodeAnalyzer.php
+++ b/src/PhpCodeAnalyzer.php
@@ -48,6 +48,11 @@ class PhpCodeAnalyzer {
     private $constantsSet = array();
     private $extensions = array();
     private $usedExtensions = array();
+    private $sinceVersion = null;
+
+    public function setSinceVersion($version){
+        $this->sinceVersion = $version;
+    }
 
     public function loadData() {
         foreach (glob(dirname(dirname(__FILE__)).'/data/*.php') as $extension_file) {
@@ -266,6 +271,13 @@ class PhpCodeAnalyzer {
         arsort($this->usedExtensions);
         foreach ($this->usedExtensions as $extension => $uses_number) {
             $extension_data = $this->extensions[$extension];
+
+            if (!is_null($this->sinceVersion) && isset($extension_data['php_version'])) {
+                if(version_compare($extension_data['php_version'], $this->sinceVersion, '<=')){
+                    continue;
+                }
+            }
+
             if (isset($extension_data['description']))
                 echo '- ['.$extension.'] '.$extension_data['description'].'.';
             else


### PR DESCRIPTION
Its not important if curl wasnt included in PHP 4.0.2 if the project your working requires PHP 5.6/7 anyway, this just gives users the option to ignore those messages in the report.